### PR TITLE
Improve Test Coverage and Add Few Rules for String Validator and Number Validator

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -29,6 +29,8 @@ const (
 	StringMin
 	StringMax
 	StringMatch
+	StringIn
+	StringInFold
 )
 
 const (

--- a/codes.go
+++ b/codes.go
@@ -37,6 +37,7 @@ const (
 	NumberRequired = rcNumber + iota
 	NumberMin
 	NumberMax
+	NumberIn
 )
 
 const (

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,71 @@
+package goval_test
+
+import (
+	"errors"
+	"github.com/pkg-id/goval"
+	"testing"
+)
+
+func TestRuleError(t *testing.T) {
+	err := goval.NewRuleError(goval.NumberMin, 2, 3)
+	exp := `{"code":3001,"input":2,"args":[3]}`
+	got := err.Error()
+	if got != exp {
+		t.Errorf("expect string Error: %q; got %q", exp, got)
+	}
+}
+
+func TestTextError(t *testing.T) {
+	err := goval.TextError("my-error")
+	exp := "my-error"
+	got := err.Error()
+	if got != exp {
+		t.Errorf("expect string Error: %q; got %q", exp, got)
+	}
+}
+
+func TestKeyError(t *testing.T) {
+	t.Run("Error: using marshal able error", func(t *testing.T) {
+		err := goval.KeyError{
+			Key: "my-key",
+			Err: goval.TextError("my-error"),
+		}
+
+		str := err.Error()
+		exp := `{"key":"my-key","err":"my-error"}`
+		if str != exp {
+			t.Errorf("expect string Error: %q; got %q", exp, str)
+		}
+	})
+
+	t.Run("Error: using an error that not implement json marshaller", func(t *testing.T) {
+		err := goval.KeyError{
+			Key: "my-key",
+			Err: errors.New("my-error"), // it should be converted by the json.Marshal of KeyError.
+		}
+
+		str := err.Error()
+		exp := `{"key":"my-key","err":"my-error"}`
+		if str != exp {
+			t.Errorf("expect string Error: %q; got %q", exp, str)
+		}
+	})
+}
+
+func TestErrors(t *testing.T) {
+	t.Run("Error: using var", func(t *testing.T) {
+		var errs goval.Errors
+		str := errs.Error()
+		if str != "null" {
+			t.Errorf("expect string Error: %q; got %q", "null", str)
+		}
+	})
+
+	t.Run("Error: using make", func(t *testing.T) {
+		errs := make(goval.Errors, 0)
+		str := errs.Error()
+		if str != "[]" {
+			t.Errorf("expect string Error: %q; got %q", "[]", str)
+		}
+	})
+}

--- a/errtrans/errtrans.go
+++ b/errtrans/errtrans.go
@@ -49,6 +49,8 @@ var ruleCodeToTemplateKey = map[goval.RuleCoder]string{
 	goval.StringMin:      "strings.min",
 	goval.StringMax:      "strings.max",
 	goval.StringMatch:    "strings.match",
+	goval.StringIn:       "strings.in",
+	goval.StringInFold:   "strings.in_fold",
 	goval.NumberRequired: "numbers.required",
 	goval.NumberMin:      "numbers.min",
 	goval.NumberMax:      "numbers.max",

--- a/errtrans/errtrans.go
+++ b/errtrans/errtrans.go
@@ -54,6 +54,7 @@ var ruleCodeToTemplateKey = map[goval.RuleCoder]string{
 	goval.NumberRequired: "numbers.required",
 	goval.NumberMin:      "numbers.min",
 	goval.NumberMax:      "numbers.max",
+	goval.NumberIn:       "numbers.in",
 	goval.SliceRequired:  "slices.required",
 	goval.SliceMin:       "slices.min",
 	goval.SliceMax:       "slices.max",

--- a/errtrans/locale/en.json
+++ b/errtrans/locale/en.json
@@ -3,6 +3,8 @@
   "strings.min": "Value must be at least {{index .Args 0}} characters long.",
   "strings.max": "Value must be less than {{index .Args 0}} characters long.",
   "strings.match": "Value {{.Input}} does not match pattern {{index .Args 0}}.",
+  "strings.in": "Value {{.Input}} is not in options: {{index .Args 0}}.",
+  "strings.in_fold": "Value {{.Input}} is not in options: {{index .Args 0}}.",
   "numbers.required": "This field is required.",
   "numbers.min": "Value must be greater than {{index .Args 0}}.",
   "numbers.max": "Value must be less than {{index .Args 0}}.",

--- a/errtrans/locale/en.json
+++ b/errtrans/locale/en.json
@@ -8,6 +8,7 @@
   "numbers.required": "This field is required.",
   "numbers.min": "Value must be greater than {{index .Args 0}}.",
   "numbers.max": "Value must be less than {{index .Args 0}}.",
+  "numbers.in": "Value {{.Input}} is not in options: {{index .Args 0}}.",
   "times.required": "This field is required.",
   "times.min": "Time must be greater than {{index .Args 0}}.",
   "times.max": "Time must be less than {{index .Args 0}}.",

--- a/errtrans/locale/id.json
+++ b/errtrans/locale/id.json
@@ -3,6 +3,8 @@
   "strings.min": "Nilai harus memiliki panjang minimal {{index .Args 0}} karakter.",
   "strings.max": "Nilai harus memiliki panjang maksimal {{index .Args 0}} karakter.",
   "strings.match": "Nilai {{.Input}} tidak cocok dengan pola {{index .Args 0}}.",
+  "strings.in": "Nilai {{.Input}} tidak ada di dalam opsi: {{index .Args 0}}.",
+  "strings.in_fold": "Nilai {{.Input}} tidak ada di dalam opsi: {{index .Args 0}}.",
   "numbers.required": "Kolom ini wajib diisi.",
   "numbers.min": "Nilai harus lebih besar dari {{index .Args 0}}.",
   "numbers.max": "Nilai harus lebih kecil dari {{index .Args 0}}.",

--- a/errtrans/locale/id.json
+++ b/errtrans/locale/id.json
@@ -8,6 +8,7 @@
   "numbers.required": "Kolom ini wajib diisi.",
   "numbers.min": "Nilai harus lebih besar dari {{index .Args 0}}.",
   "numbers.max": "Nilai harus lebih kecil dari {{index .Args 0}}.",
+  "numbers.in": "Nilai {{.Input}} tidak ada di dalam opsi: {{index .Args 0}}.",
   "times.required": "Kolom ini wajib diisi.",
   "times.min": "Waktu harus lebih besar dari {{index .Args 0}}.",
   "times.max": "Waktu harus lebih kecil dari {{index .Args 0}}.",

--- a/funcs/funcs.go
+++ b/funcs/funcs.go
@@ -1,0 +1,10 @@
+package funcs
+
+func Contains[T comparable, P func(value T) bool](values []T, predicate P) bool {
+	for i := range values {
+		if predicate(values[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/funcs/funcs.go
+++ b/funcs/funcs.go
@@ -1,5 +1,6 @@
 package funcs
 
+// Contains returns true if one of the given values satisfy the predicate.
 func Contains[T comparable, P func(value T) bool](values []T, predicate P) bool {
 	for i := range values {
 		if predicate(values[i]) {

--- a/funcs/funcs_test.go
+++ b/funcs/funcs_test.go
@@ -1,0 +1,18 @@
+package funcs_test
+
+import (
+	"github.com/pkg-id/goval/funcs"
+	"testing"
+)
+
+func TestContains(t *testing.T) {
+	ok := funcs.Contains([]int{1, 2, 4}, func(value int) bool { return value == 2 })
+	if !ok {
+		t.Fatalf("expect ok")
+	}
+
+	ok = funcs.Contains([]int{1, 3, 4}, func(value int) bool { return value == 2 })
+	if ok {
+		t.Fatalf("expect not ok")
+	}
+}

--- a/goval_test.go
+++ b/goval_test.go
@@ -1,0 +1,94 @@
+package goval_test
+
+import (
+	"context"
+	"errors"
+	"github.com/pkg-id/goval"
+	"testing"
+)
+
+func TestNamed(t *testing.T) {
+	t.Run("when validation fails", func(t *testing.T) {
+		ctx := context.Background()
+		err := goval.Named("field-name", "", goval.String().Required()).Validate(ctx)
+
+		var exp *goval.KeyError
+		if !errors.As(err, &exp) {
+			t.Fatalf("expect error type: %T; got error type: %T", exp, err)
+		}
+
+		if exp.Key != "field-name" {
+			t.Errorf("expect error key is field-name; got %s", exp.Key)
+		}
+
+		if exp.Err == nil {
+			t.Errorf("expect error is not nil")
+		}
+	})
+
+	t.Run("when validation ok", func(t *testing.T) {
+		ctx := context.Background()
+		err := goval.Named("field-name", "a", goval.String().Required()).Validate(ctx)
+		if err != nil {
+			t.Fatalf("expect not error")
+		}
+	})
+}
+
+func TestEach(t *testing.T) {
+	t.Run("when validation fails", func(t *testing.T) {
+		ctx := context.Background()
+		val := []string{"a", "bc", "d", "ef"}
+
+		err := goval.Each(goval.String().Required().Min(2).Build).Build(val).Validate(ctx)
+		var exp goval.Errors
+		if !errors.As(err, &exp) {
+			t.Fatalf("expect error type: %T; got error type: %T", exp, err)
+		}
+
+		if len(exp) != 2 {
+			t.Fatalf("expect two errors")
+		}
+	})
+
+	t.Run("when validation ok", func(t *testing.T) {
+		ctx := context.Background()
+		val := []string{"aa", "bc", "dd", "ef"}
+
+		err := goval.Each(goval.String().Required().Min(2).Build).Build(val).Validate(ctx)
+		if err != nil {
+			t.Fatalf("expect not error")
+		}
+	})
+}
+
+func TestExecute(t *testing.T) {
+	t.Run("when validation fails", func(t *testing.T) {
+		ctx := context.Background()
+
+		err := goval.Execute(ctx,
+			goval.String().Required().Min(2).Build("a"),
+			goval.Number[int]().Required().Min(8).Build(7),
+		)
+		var exp goval.Errors
+		if !errors.As(err, &exp) {
+			t.Fatalf("expect error type: %T; got error type: %T", exp, err)
+		}
+
+		if len(exp) != 2 {
+			t.Fatalf("expect two errors")
+		}
+	})
+
+	t.Run("when validation ok", func(t *testing.T) {
+		ctx := context.Background()
+
+		err := goval.Execute(ctx,
+			goval.String().Required().Min(2).Build("ab"),
+			goval.Number[int]().Required().Min(8).Build(8),
+		)
+		if err != nil {
+			t.Fatalf("expect not error")
+		}
+	})
+}

--- a/govalregex/govalregex.go
+++ b/govalregex/govalregex.go
@@ -10,11 +10,11 @@ const (
 )
 
 var (
-	// AlphaNumeric is a lazy compiled regex for alpha numeric characters only.
+	// AlphaNumeric is a lazy-compiled regex for alphanumeric characters only.
 	AlphaNumeric = NewLazy(alphaNumericRegexString)
 )
 
-// LazyCompiler is a lazy compiled regex.
+// LazyCompiler is a lazy-compiled regex.
 // That is, the regex is compiled only when the RegExp method is called.
 type LazyCompiler struct {
 	once     sync.Once

--- a/govalregex/govalregex_test.go
+++ b/govalregex/govalregex_test.go
@@ -1,0 +1,20 @@
+package govalregex
+
+import "testing"
+
+func TestLazyCompiler_RegExp(t *testing.T) {
+	re := NewLazy(`^[a-z]+$`)
+	if re.compiled != nil {
+		t.Errorf("expect no value until first request is created")
+	}
+
+	c1 := re.RegExp()
+	if c1 == nil {
+		t.Fatalf("expect not nil")
+	}
+
+	c2 := re.RegExp()
+	if c1 != c2 {
+		t.Errorf("expect c1 and c2 is equal")
+	}
+}

--- a/numbers.go
+++ b/numbers.go
@@ -2,7 +2,7 @@ package goval
 
 import (
 	"context"
-
+	"github.com/pkg-id/goval/funcs"
 	"golang.org/x/exp/constraints"
 )
 
@@ -55,6 +55,17 @@ func (nv NumberValidator[T]) Max(max T) NumberValidator[T] {
 	return nv.With(func(ctx context.Context, value T) error {
 		if value > max {
 			return NewRuleError(NumberMax, value, max)
+		}
+		return nil
+	})
+}
+
+// In ensures that the provided number is one of the specified options.
+func (nv NumberValidator[T]) In(options ...T) NumberValidator[T] {
+	return nv.With(func(ctx context.Context, value T) error {
+		ok := funcs.Contains(options, func(opt T) bool { return opt == value })
+		if !ok {
+			return NewRuleError(NumberIn, value, options)
 		}
 		return nil
 	})

--- a/string.go
+++ b/string.go
@@ -2,6 +2,8 @@ package goval
 
 import (
 	"context"
+	"github.com/pkg-id/goval/funcs"
+	"strings"
 )
 
 // StringValidator is a FunctionValidator that validates string.
@@ -58,6 +60,29 @@ func (sv StringValidator) Match(pattern Pattern) StringValidator {
 		exp := pattern.RegExp()
 		if !exp.MatchString(value) {
 			return NewRuleError(StringMatch, value, exp.String())
+		}
+		return nil
+	})
+}
+
+// In ensures that the provided string is one of the specified options.
+// This validation is case-sensitive, use InFold to perform a case-insensitive In validation.
+func (sv StringValidator) In(options ...string) StringValidator {
+	return sv.With(func(ctx context.Context, value string) error {
+		ok := funcs.Contains(options, func(opt string) bool { return value == opt })
+		if !ok {
+			return NewRuleError(StringIn, value, options)
+		}
+		return nil
+	})
+}
+
+// InFold ensures that the provided string is one of the specified options with case-insensitivity.
+func (sv StringValidator) InFold(options ...string) StringValidator {
+	return sv.With(func(ctx context.Context, value string) error {
+		ok := funcs.Contains(options, func(opt string) bool { return strings.EqualFold(value, opt) })
+		if !ok {
+			return NewRuleError(StringInFold, value, options)
 		}
 		return nil
 	})

--- a/string_test.go
+++ b/string_test.go
@@ -145,6 +145,70 @@ func TestStringValidator_Match(t *testing.T) {
 	}
 }
 
+func TestStringValidator_In(t *testing.T) {
+	ctx := context.Background()
+	err := goval.String().In("a", "b", "c").Build("a").Validate(ctx)
+	if err != nil {
+		t.Errorf("expect no error; got error: %v", err)
+	}
+
+	err = goval.String().In("a", "b", "c").Build("A").Validate(ctx)
+	var exp *goval.RuleError
+	if !errors.As(err, &exp) {
+		t.Fatalf("expect error type: %T; got error type: %T", exp, err)
+	}
+
+	if !exp.Code.Equal(goval.StringIn) {
+		t.Errorf("expect the error code: %v; got error code: %v", goval.StringIn, exp.Code)
+	}
+
+	inp, ok := exp.Input.(string)
+	if !ok {
+		t.Fatalf("expect the error input type: %T; got error input: %T", "", exp.Input)
+	}
+
+	if inp != "A" {
+		t.Errorf("expect the error input value: %q; got error input value: %q", "", inp)
+	}
+
+	args := []any{[]string{"a", "b", "c"}}
+	if !reflect.DeepEqual(exp.Args, args) {
+		t.Errorf("expect the error args: %v; got error args: %v", args, exp.Args)
+	}
+}
+
+func TestStringValidator_InFold(t *testing.T) {
+	ctx := context.Background()
+	err := goval.String().InFold("a", "b", "c").Build("C").Validate(ctx)
+	if err != nil {
+		t.Errorf("expect no error; got error: %v", err)
+	}
+
+	err = goval.String().InFold("a", "b", "c").Build("Z").Validate(ctx)
+	var exp *goval.RuleError
+	if !errors.As(err, &exp) {
+		t.Fatalf("expect error type: %T; got error type: %T", exp, err)
+	}
+
+	if !exp.Code.Equal(goval.StringInFold) {
+		t.Errorf("expect the error code: %v; got error code: %v", goval.StringInFold, exp.Code)
+	}
+
+	inp, ok := exp.Input.(string)
+	if !ok {
+		t.Fatalf("expect the error input type: %T; got error input: %T", "", exp.Input)
+	}
+
+	if inp != "Z" {
+		t.Errorf("expect the error input value: %q; got error input value: %q", "", inp)
+	}
+
+	args := []any{[]string{"a", "b", "c"}}
+	if !reflect.DeepEqual(exp.Args, args) {
+		t.Errorf("expect the error args: %v; got error args: %v", args, exp.Args)
+	}
+}
+
 func BenchmarkStringValidator_Build(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = goval.String().Build("")


### PR DESCRIPTION
Improved test coverage for the following functions:

-  `goval.Named`
-  `goval.Each`
-  `goval.Execute`
-  `goval.Errors`
-  `goval.KeyError`
- `goval.TextError`
- `goval.RuleError`
- `govalregex.LazyCompiler`

Added new rules for the String Validator:

- `In`: ensures that a string is one of the specified options (case-sensitive).
- `InFold`: same as `In` but case-insensitive.

Added new rules for the Number Validator:

- `In`: ensures that the provided number is one of the specified options.

In addition, a new sub-package called **funcs** has been added for functional programming utilities

-  `Contains` : returns `true` if the given values satisfy the `predicate`.