### PR TITLE
refactor/remove-duplicate-code

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -120,6 +120,12 @@ var _ jsonErrorStringer = make(Errors, 0)
 func (e Errors) Error() string                { return e.String() }
 func (e Errors) String() string               { return stringifyJSON(e) }
 func (e Errors) MarshalJSON() ([]byte, error) { return json.Marshal([]error(e)) }
+func (e Errors) NilOrErr() error {
+	if len(e) > 0 {
+		return e
+	}
+	return nil
+}
 
 // stringifyJSON converts a json.Marshaler to a string.
 // If the json.Marshaler returns an error, the error is returned as a string.

--- a/errors.go
+++ b/errors.go
@@ -120,7 +120,7 @@ var _ jsonErrorStringer = make(Errors, 0)
 func (e Errors) Error() string                { return e.String() }
 func (e Errors) String() string               { return stringifyJSON(e) }
 func (e Errors) MarshalJSON() ([]byte, error) { return json.Marshal([]error(e)) }
-func (e Errors) NilOrErr() error {
+func (e Errors) NilIfEmpty() error {
 	if len(e) > 0 {
 		return e
 	}

--- a/funcs/funcs.go
+++ b/funcs/funcs.go
@@ -9,3 +9,29 @@ func Contains[T comparable, P func(value T) bool](values []T, predicate P) bool 
 	}
 	return false
 }
+
+// Map transform the given values into another slice, and map each value to another value by using the given mapper.
+func Map[I, O any](values []I, mapper func(inp I) O) []O {
+	return Reduce(values, make([]O, 0, len(values)), func(acc []O, cur I) []O {
+		return append(acc, mapper(cur))
+	})
+}
+
+// Reduce executes a user-supplied "reducer" callback function on each element of the array, in order,
+// passing in the return value from the calculation on the preceding element.
+func Reduce[I, O any](values []I, init O, reducer func(accumulator O, current I) O) O {
+	var accumulator = init
+	for _, inp := range values {
+		accumulator = reducer(accumulator, inp)
+	}
+	return accumulator
+}
+
+// Values get the values of map.
+func Values[K comparable, V any](m map[K]V) []V {
+	outs := make([]V, 0, len(m))
+	for k := range m {
+		outs = append(outs, m[k])
+	}
+	return outs
+}

--- a/funcs/funcs_test.go
+++ b/funcs/funcs_test.go
@@ -2,6 +2,8 @@ package funcs_test
 
 import (
 	"github.com/pkg-id/goval/funcs"
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -14,5 +16,42 @@ func TestContains(t *testing.T) {
 	ok = funcs.Contains([]int{1, 3, 4}, func(value int) bool { return value == 2 })
 	if ok {
 		t.Fatalf("expect not ok")
+	}
+}
+
+func TestMap(t *testing.T) {
+	outs := funcs.Map([]int{1, 2, 3}, func(inp int) int {
+		return inp * 2
+	})
+
+	exp := []int{2, 4, 6}
+	if !reflect.DeepEqual(outs, exp) {
+		t.Fatalf("expect %v; got %v", exp, outs)
+	}
+}
+
+func TestValues(t *testing.T) {
+	inp := map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}
+
+	outs := funcs.Values(inp)
+	sort.Ints(outs)
+	exp := []int{1, 2, 3}
+	if !reflect.DeepEqual(outs, exp) {
+		t.Fatalf("expect %v; got %v", exp, outs)
+	}
+}
+
+func TestReduce(t *testing.T) {
+	sum := funcs.Reduce([]int{1, 2, 3}, 0, func(acc, inp int) int {
+		return acc + inp
+	})
+
+	exp := 1 + 2 + 3
+	if sum != exp {
+		t.Fatalf("expect %v; got %v", exp, sum)
 	}
 }

--- a/goval.go
+++ b/goval.go
@@ -2,6 +2,7 @@ package goval
 
 import (
 	"context"
+	"github.com/pkg-id/goval/funcs"
 	"regexp"
 )
 
@@ -118,34 +119,47 @@ func Named[T any, B Builder[T]](name string, value T, validator B) Validator {
 func Each[T any, V []T](fn func(each T) Validator) Builder[V] {
 	return BuilderFunc[V](func(values V) Validator {
 		return ValidatorFunc(func(ctx context.Context) error {
-			return each(ctx, values, fn)
+			return execute(ctx, funcs.Map(values, fn))
 		})
 	})
 }
 
-// each executes the given function for each element in the slice.
-func each[T any, V []T](ctx context.Context, values V, fn func(value T) Validator) error {
-	errs := make(Errors, 0)
-	for _, value := range values {
-		err := fn(value).Validate(ctx)
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	return errs.NilOrErr()
-}
-
 // Execute executes the given validators and collects the errors into a single error
 func Execute(ctx context.Context, validators ...Validator) error {
-	errs := make(Errors, 0)
-	for _, validator := range validators {
+	return execute(ctx, validators)
+}
+
+// execute executes the given validators and collects the errors into a single error.
+func execute(ctx context.Context, validators []Validator) error {
+	internalError := make(chan error, 1)
+	validateError := make(chan error, 1)
+	reducer := validatorReducer(ctx, internalError)
+	go func() {
+		validateError <- funcs.
+			Reduce(validators, Errors{}, reducer).
+			NilIfEmpty()
+	}()
+	select {
+	case ie := <-internalError:
+		return ie
+	case ve := <-validateError:
+		return ve
+	}
+}
+
+func validatorReducer(ctx context.Context, internalError chan error) func(errs Errors, validator Validator) Errors {
+	return func(errs Errors, validator Validator) Errors {
 		err := validator.Validate(ctx)
 		if err != nil {
-			errs = append(errs, err)
+			switch err.(type) {
+			default:
+				internalError <- err
+			case *RuleError, Errors:
+				errs = append(errs, err)
+			}
 		}
+		return errs
 	}
-	return errs.NilOrErr()
 }
 
 // Pattern is an interface that defines the regular expression pattern.

--- a/goval.go
+++ b/goval.go
@@ -133,30 +133,19 @@ func each[T any, V []T](ctx context.Context, values V, fn func(value T) Validato
 		}
 	}
 
-	if len(errs) != 0 {
-		return errs
-	}
-
-	return nil
+	return errs.NilOrErr()
 }
 
 // Execute executes the given validators and collects the errors into a single error
 func Execute(ctx context.Context, validators ...Validator) error {
 	errs := make(Errors, 0)
 	for _, validator := range validators {
-		if validator != nil {
-			err := validator.Validate(ctx)
-			if err != nil {
-				errs = append(errs, err)
-			}
+		err := validator.Validate(ctx)
+		if err != nil {
+			errs = append(errs, err)
 		}
 	}
-
-	if len(errs) != 0 {
-		return errs
-	}
-
-	return nil
+	return errs.NilOrErr()
 }
 
 // Pattern is an interface that defines the regular expression pattern.

--- a/goval_test.go
+++ b/goval_test.go
@@ -91,4 +91,22 @@ func TestExecute(t *testing.T) {
 			t.Fatalf("expect not error")
 		}
 	})
+
+	t.Run("when error is unknown type", func(t *testing.T) {
+		ctx := context.Background()
+
+		internalError := errors.New("internal error")
+		customValidator := func(ctx context.Context, value int) error {
+			return internalError
+		}
+
+		err := goval.Execute(ctx,
+			goval.String().Required().Min(2).Build("a"),
+			goval.Number[int]().Required().With(customValidator).Build(8),
+		)
+
+		if err != internalError {
+			t.Fatalf("expect validation error is discarded and internal error is returned; but got %v", err)
+		}
+	})
 }

--- a/maps.go
+++ b/maps.go
@@ -65,10 +65,6 @@ func (mv MapValidator[K, V]) Each(validator Builder[V]) MapValidator[K, V] {
 				}
 			}
 		}
-
-		if len(errs) > 0 {
-			return errs
-		}
-		return nil
+		return errs.NilOrErr()
 	}
 }

--- a/slice.go
+++ b/slice.go
@@ -1,6 +1,9 @@
 package goval
 
-import "context"
+import (
+	"context"
+	"github.com/pkg-id/goval/funcs"
+)
 
 // SliceValidator is a FunctionValidator that validates slices.
 type SliceValidator[T any, V []T] FunctionValidator[V]
@@ -54,17 +57,7 @@ func (sv SliceValidator[T, V]) Max(max int) SliceValidator[T, V] {
 // Each ensures each element of the slice is satisfied by the given validator.
 func (sv SliceValidator[T, V]) Each(validator Builder[T]) SliceValidator[T, V] {
 	return func(ctx context.Context, values V) error {
-		errs := make(Errors, 0)
-		for _, value := range values {
-			if err := validator.Build(value).Validate(ctx); err != nil {
-				switch et := err.(type) {
-				default:
-					return err
-				case *RuleError:
-					errs = append(errs, et)
-				}
-			}
-		}
-		return errs.NilOrErr()
+		validators := funcs.Map(values, validator.Build)
+		return execute(ctx, validators)
 	}
 }

--- a/slice.go
+++ b/slice.go
@@ -65,11 +65,6 @@ func (sv SliceValidator[T, V]) Each(validator Builder[T]) SliceValidator[T, V] {
 				}
 			}
 		}
-
-		if len(errs) > 0 {
-			return errs
-		}
-
-		return nil
+		return errs.NilOrErr()
 	}
 }


### PR DESCRIPTION
What do you think about these changes, @dimasadyaksa? Basically, the changes are meant to remove duplicate logic for executing the validator. As we can see, the code block below is used in a few places:

```go
errs := make(Errors, 0)
for _, value := range values {
	if err := validator.Build(value).Validate(ctx); err != nil {
		switch et := err.(type) {
		default:
			return err
		case *RuleError:
			errs = append(errs, et)
		}
	}
}

if len(errs) > 0 {
	return errs
}
```
The code can be replaced by the newly added function called `execute`. These changes are useful for centralizing error handling. For example, I also added a new kind of error called `InternalError`. This error is a kind of error that needs to be excluded from validation errors, such as database-related errors. With these changes, if we need to add another error, we just need to modify the `execute` function.