### PR TITLE
Add String Variant Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,9 @@
 
 **Goval** or **Go Validator** is a package for value validation in Go.
 
-The objective of this package is to provide a simple and easy-to-use validation library for Go that is easy to integrate
-into existing projects, and easy for developers to use.
-The package should be easy to extend and should provide a simple way to add custom validators, with no magic happening
-behind the scenes to make it easy to understand and debug as well.
-
-This package is designed to enhance the capabilities of the Go function as a first-class citizen. That means everything
-in this package is built using function composition. Each validation rule is a simple function that can be chained (
-composed) together to create complex validation logic. This package is also designed to avoid using reflection as much
-as possible and is safe for concurrent use.
-
-## How to Contribute?
-
-The package is still under development and requires more validation rules to be implemented. If you would like to
-contribute to this project, your contributions would be greatly appreciated. To contribute, simply fork the project and
-send us a pull request. Although there is no formal format for contributing at the moment, we would appreciate it if you
-could provide a good explanation with your pull request.
-
-When you clone this repository, please make sure to run `make setup` to install the required dependencies for development
-and also to set up the `pre-commit` hooks. Additionally, when you create a commit, the `pre-commit` hooks will check if the
-commit follows our standard. We use Conventional Commits.
+This Go packages aims to provide a user-friendly validation library that is easy to integrate, extend, and use. 
+It utilizes function composition for building complex validation logic and avoids reflection for improved performance. 
+It is designed to enhance the capabilities of Go functions and is safe for concurrent use.
 
 ## Features
 
@@ -36,6 +19,11 @@ commit follows our standard. We use Conventional Commits.
 * [No Reflection](#no-reflection)
 * [Support for Customizable and Translatable Error Messages](#support-for-customizable-and-translatable-error-messages)
 
+## Installation
+
+```shell
+go get github.com/pkg-id/goval
+```
 
 ## Feature Details
 
@@ -62,6 +50,7 @@ This means that if you already have common validation rules, you can create a ne
 validator := goval.String().Required().Min(2).Max(9)
 extendedValidator := validator.Match(govalregex.AlphaNumeric)
 
+ctx := context.Background()
 fmt.Println(validator.Validate(ctx, "hello!"))          // err: <nil>
 fmt.Println(extendedValidator.Validate(ctx, "hello!"))  // err: {"code":2003,"args":["^[a-zA-Z0-9]+$"]}
 ```
@@ -315,7 +304,7 @@ Just execute again, and this will be the final error, with the key and a human-r
 ]
 ```
 
-### No Reflection
+### Zero Reflection
 This package utilizes a new feature in Go called "Generic" to eliminate the need for the `reflect` package.
 
 ### Support for Customizable and Translatable Error Messages
@@ -334,6 +323,16 @@ err := goval.Execute(ctx,
     goval.Named[[]SocialMedia]("social_media_list", req.SocialMediaList, goval.Slice[SocialMedia]().Required().EachFunc(SocialMediaValidator)),
 )
 ```
+
+## How to Contribute?
+
+If you would like to contribute to this project, your contributions would be greatly appreciated. To contribute, 
+simply fork the project and send us a pull request. Although there is no formal format for contributing at the moment, 
+we would appreciate it if you could provide a good explanation with your pull request.
+
+When you clone this repository, please make sure to run `make setup` to install the required dependencies for development
+and also to set up the `pre-commit` hooks. Additionally, when you create a commit, the `pre-commit` hooks will check if the
+commit follows our standard. We use Conventional Commits.
 
 ## License
 

--- a/errors.go
+++ b/errors.go
@@ -134,3 +134,18 @@ func stringifyJSON(m json.Marshaler) string {
 	}
 	return string(b)
 }
+
+// InternalError is an error wrapper to indicate an internal error.
+// If goval got this type of error, it will not include in Errors and KeyError.
+type InternalError struct {
+	Err error
+}
+
+// NewInternalError creates a new InternalError.
+func NewInternalError(err error) *InternalError {
+	return &InternalError{Err: err}
+}
+
+func (e *InternalError) Error() string  { return e.String() }
+func (e *InternalError) Unwrap() error  { return e.Err }
+func (e *InternalError) String() string { return "goval.InternalError: " + e.Err.Error() }

--- a/goval_test.go
+++ b/goval_test.go
@@ -34,6 +34,39 @@ func TestNamed(t *testing.T) {
 			t.Fatalf("expect not error")
 		}
 	})
+
+	t.Run("internal error", func(t *testing.T) {
+		ctx := context.Background()
+
+		retErr := errors.New("internal error")
+		custom := func(ctx context.Context, value string) error {
+			return goval.NewInternalError(retErr)
+		}
+
+		err := goval.Named("field-name", "a", goval.String().With(custom)).Validate(ctx)
+		if !errors.Is(err, retErr) {
+			t.Fatalf("expect error is internal error")
+		}
+	})
+
+	t.Run("without internal error", func(t *testing.T) {
+		ctx := context.Background()
+
+		retErr := errors.New("internal error")
+		custom := func(ctx context.Context, value string) error {
+			return retErr
+		}
+
+		err := goval.Named("field-name", "a", goval.String().With(custom)).Validate(ctx)
+		var kErr *goval.KeyError
+		if !errors.As(err, &kErr) {
+			t.Fatalf("expect error type: %T; got error type: %T", kErr, err)
+		}
+
+		if !errors.Is(kErr.Err, retErr) {
+			t.Fatalf("expect error is internal error")
+		}
+	})
 }
 
 func TestEach(t *testing.T) {

--- a/string.go
+++ b/string.go
@@ -3,31 +3,43 @@ package goval
 import (
 	"context"
 	"fmt"
-	"github.com/pkg-id/goval/funcs"
 	"strings"
+
+	"github.com/pkg-id/goval/funcs"
 )
 
 // StringValidator is a FunctionValidator that validates string.
-type StringValidator FunctionValidator[string]
+// For backward compatibility.
+type StringValidator = SVV[string]
 
 // String returns a StringValidator with no rules.
+// For backward compatibility.
 func String() StringValidator {
-	return NopFunctionValidator[string]
+	return StringVariant[string]()
+}
+
+// SVV (String Variant Validator) is a FunctionValidator that validates string
+// variants.
+type SVV[T ~string] FunctionValidator[T]
+
+// StringVariant returns a SVV with no rules.
+func StringVariant[T ~string]() SVV[T] {
+	return NopFunctionValidator[T]
 }
 
 // Validate executes the validation rules immediately.
-func (f StringValidator) Validate(ctx context.Context, value string) error {
+func (f SVV[T]) Validate(ctx context.Context, value T) error {
 	return validatorOf(f, value).Validate(ctx)
 }
 
 // With attaches the next rule to the chain.
-func (f StringValidator) With(next StringValidator) StringValidator {
+func (f SVV[T]) With(next SVV[T]) SVV[T] {
 	return Chain(f, next)
 }
 
 // Required ensures the string is not empty.
-func (f StringValidator) Required() StringValidator {
-	return f.With(func(ctx context.Context, value string) error {
+func (f SVV[T]) Required() SVV[T] {
+	return f.With(func(ctx context.Context, value T) error {
 		if value == "" {
 			return NewRuleError(StringRequired)
 		}
@@ -36,8 +48,8 @@ func (f StringValidator) Required() StringValidator {
 }
 
 // Min ensures the length of the string is not less than the given length.
-func (f StringValidator) Min(length int) StringValidator {
-	return f.With(func(ctx context.Context, value string) error {
+func (f SVV[T]) Min(length int) SVV[T] {
+	return f.With(func(ctx context.Context, value T) error {
 		if len(value) < length {
 			return NewRuleError(StringMin, length)
 		}
@@ -46,8 +58,8 @@ func (f StringValidator) Min(length int) StringValidator {
 }
 
 // Max ensures the length of the string is not greater than the given length.
-func (f StringValidator) Max(length int) StringValidator {
-	return f.With(func(ctx context.Context, value string) error {
+func (f SVV[T]) Max(length int) SVV[T] {
+	return f.With(func(ctx context.Context, value T) error {
 		if len(value) > length {
 			return NewRuleError(StringMax, length)
 		}
@@ -57,8 +69,8 @@ func (f StringValidator) Max(length int) StringValidator {
 
 // Match ensures the string matches the given pattern.
 // If pattern cause panic, will be recovered.
-func (f StringValidator) Match(pattern Pattern) StringValidator {
-	return f.With(func(ctx context.Context, value string) (err error) {
+func (f SVV[T]) Match(pattern Pattern) SVV[T] {
+	return f.With(func(ctx context.Context, value T) (err error) {
 		defer func() {
 			if rec := recover(); rec != nil {
 				err = fmt.Errorf("panic: %v", rec)
@@ -66,7 +78,7 @@ func (f StringValidator) Match(pattern Pattern) StringValidator {
 		}()
 
 		exp := pattern.RegExp()
-		if !exp.MatchString(value) {
+		if !exp.MatchString(string(value)) {
 			return NewRuleError(StringMatch, exp.String())
 		}
 
@@ -76,9 +88,9 @@ func (f StringValidator) Match(pattern Pattern) StringValidator {
 
 // In ensures that the provided string is one of the specified options.
 // This validation is case-sensitive, use InFold to perform a case-insensitive In validation.
-func (f StringValidator) In(options ...string) StringValidator {
-	return f.With(func(ctx context.Context, value string) error {
-		ok := funcs.Contains(options, func(opt string) bool { return value == opt })
+func (f SVV[T]) In(options ...T) SVV[T] {
+	return f.With(func(ctx context.Context, value T) error {
+		ok := funcs.Contains(options, func(opt T) bool { return value == opt })
 		if !ok {
 			return NewRuleError(StringIn, options)
 		}
@@ -87,9 +99,9 @@ func (f StringValidator) In(options ...string) StringValidator {
 }
 
 // InFold ensures that the provided string is one of the specified options with case-insensitivity.
-func (f StringValidator) InFold(options ...string) StringValidator {
-	return f.With(func(ctx context.Context, value string) error {
-		ok := funcs.Contains(options, func(opt string) bool { return strings.EqualFold(value, opt) })
+func (f SVV[T]) InFold(options ...T) SVV[T] {
+	return f.With(func(ctx context.Context, value T) error {
+		ok := funcs.Contains(options, func(opt T) bool { return strings.EqualFold(string(value), string(opt)) })
 		if !ok {
 			return NewRuleError(StringInFold, options)
 		}
@@ -104,6 +116,6 @@ func (f StringValidator) InFold(options ...string) StringValidator {
 //
 // The mapper function takes a StringValidator instance and returns a new StringValidator instance with
 // additional validation logic.
-func (f StringValidator) When(p Predicate[string], m Mapper[string, StringValidator]) StringValidator {
+func (f SVV[T]) When(p Predicate[T], m Mapper[T, SVV[T]]) SVV[T] {
 	return whenLinker(f, p, m)
 }


### PR DESCRIPTION
This feature basically provides a simple `StringValidator` for string variants (`~string`). In the current latest version, if we need a validator for the `type VariantExample string`, which is a string variant, we have to convert `VariantExample` to a `string` in order to use the `StringValidator`. These changes add a new API that reuses the `StringValidator` rules for string variants without any conversion.


**Before:**  

```go
type Variant string

const (
   VariantA Variant = "A"
   VariantB Variant = "B"
)

var validator = goval.String().In(string(VariantA), string(VariantB))
```

**After:**  

```go
type Variant string

const (
   VariantA Variant = "A"
   VariantB Variant = "B"
)

var validator = goval.StringVariant[Variant]().In(VariantA, VariantB)
```
