### PR TITLE
PoC : regex/s are vulnerable for validation

### DIFF
--- a/examples/fuzz/main.go
+++ b/examples/fuzz/main.go
@@ -38,9 +38,9 @@ func test_rgb() {
 func test_numeric() {
 	fmt.Println("\n\ntest_numeric()")
 
-	zero := "0"     // result : invalid
+	zero := "0"     // result : valid
 	minZero := "-0" // result : valid
-	validator := goval.String().Required().Min(2).Match(govalregex.Numeric)
+	validator := goval.String().Required().Match(govalregex.Numeric)
 	ctx := context.Background()
 	for _, v := range []string{zero, minZero} {
 		validateErr := validator.Validate(ctx, v)

--- a/examples/fuzz/main.go
+++ b/examples/fuzz/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/mail"
+
+	"github.com/pkg-id/goval"
+	"github.com/pkg-id/goval/govalregex"
+)
+
+func main() {
+	test_email()
+	test_numeric()
+	test_rgb()
+}
+
+func test_rgb() {
+	fmt.Println("\n\ntest_numeric()")
+
+	rgbValues := []string{
+		"rgb(50%, 25%, 75%))",  // invalid double ))
+		"rgb(100%, 101%, 50%)", // should invalid value : 101%
+		"rgb(50%, 25%, 75%)",   // valid
+	}
+	validator := goval.String().Required().Min(2).Match(govalregex.RGB)
+	ctx := context.Background()
+	for _, v := range rgbValues {
+		validateErr := validator.Validate(ctx, v)
+		if validateErr == nil {
+			fmt.Println("govalregex RGB is valid : ", v)
+		} else {
+			fmt.Println("govalregex RGB isn't valid : ", v)
+		}
+	}
+}
+
+func test_numeric() {
+	fmt.Println("\n\ntest_numeric()")
+
+	zero := "0"     // result : invalid
+	minZero := "-0" // result : valid
+	validator := goval.String().Required().Min(2).Match(govalregex.Numeric)
+	ctx := context.Background()
+	for _, v := range []string{zero, minZero} {
+		validateErr := validator.Validate(ctx, v)
+		if validateErr == nil {
+			fmt.Println("govalregex numeric, v is valid : ", v)
+		} else {
+			fmt.Println("govalregex numeric, v isn't valid : ", v)
+		}
+	}
+}
+
+func test_email() {
+	fmt.Println("test_email()")
+
+	email := "user@example.com." // invalid email
+	validator := goval.String().Required().Min(2).Match(govalregex.Email)
+	ctx := context.Background()
+	validateErr := validator.Validate(ctx, email)
+	if validateErr == nil {
+		fmt.Println("govalregex email is valid : ", email)
+	} else {
+		fmt.Println("govalregex email isn't valid : ", email)
+	}
+
+	// easy way to validate email
+	// or another way is use validate/v10 package
+	e, parseErr := mail.ParseAddress(email)
+	if parseErr == nil {
+		fmt.Println("net/mail email is valid : ", e)
+	} else {
+		fmt.Println("net/mail email isn't valid : ", e)
+	}
+}


### PR DESCRIPTION
TL;DR : request to remove some regex-base validation, like email regex validation.
Background : So many CVE's cause by Regex (See : https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=regex )
1. Please use Regex wisely, there is email validation using regex and Go has std package/s like validation/v10 or net/mail .
2. Use Regex for validating data with limited character types. Example to validate valid names in id_ID where characters are limited to A-Za-z, with the addition of space, dash and/or a single tick/quote, you can use a regex pattern for validate that name-type.
3. If there isn't a regex pattern available or too hard to create for validating specific data, consider using string replacement and validating each separated part of the data/value, it's more safe and clear to see.
4. And please provide datasets as well for testing each regex base validation/s .

note : user@example.com. (with dot in the end) is valid email for regex validation.